### PR TITLE
Removed representation exposure, added test cases to ensure removal o…

### DIFF
--- a/app/src/main/java/com/nullpointers/pathpointer/Building.java
+++ b/app/src/main/java/com/nullpointers/pathpointer/Building.java
@@ -1,5 +1,7 @@
 package com.nullpointers.pathpointer;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -125,7 +127,7 @@ public class Building {
     public Iterator<Facility> facilityIterator(FacilityType type) {
         if (facilities.containsKey(type)) {
             // If there are some facilities of this type, the type will appear in the map
-            return facilities.get(type).iterator();
+            return Collections.unmodifiableMap(facilities).get(type).iterator();
         } else {
             // If there are no facilities of this type, the type will not appear in the map
             // Return an iterator to an empty set
@@ -135,7 +137,7 @@ public class Building {
 
     /** Returns an Iterator which can be used to traverse all Rooms in this Building */
     public Iterator<Room> roomIterator() {
-        return rooms.iterator();
+        return Collections.unmodifiableSet(rooms).iterator();
     }
 
 }

--- a/app/src/test/java/com/nullpointers/pathpointer/BuildingTest.java
+++ b/app/src/test/java/com/nullpointers/pathpointer/BuildingTest.java
@@ -60,6 +60,7 @@ public class BuildingTest {
         facA = new HashSet<>();
         for (int i = 0; i < 2 * typeA.length; i++) {
             facA.add(new Facility(locID, buildID, i * 1.4, i + 4.0, typeA[i % typeA.length]));
+            locID++;
         }
 
         FacilityType[] typeB = {FacilityType.Bathroom, FacilityType.WaterFountain,
@@ -68,6 +69,7 @@ public class BuildingTest {
         facB = new HashSet<>();
         for (int i = 0; i < 2 * typeB.length; i++) {
             facB.add(new Facility(locID, buildID, i * 1.4, i + 4.0, typeB[i % typeB.length]));
+            locID++;
         }
 
         // These building object will be used repeatedly throughout these test cases
@@ -236,5 +238,35 @@ public class BuildingTest {
         // [bB] contains no vending machines; use this building to test this branch
         Iterator<Facility> iter = bB.facilityIterator(FacilityType.VendingMachine);
         assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void testFacilityImmutability() {
+        // Iterators should not cause representation exposure and violate immutability
+        Iterator<Facility> iter = bA.facilityIterator(FacilityType.Bathroom);
+        boolean flag = false;
+        try {
+            iter.remove();
+        } catch (Exception e) {
+            flag = true;
+        }
+
+        assertTrue(flag);
+        assertEquals(facA.size(), bA.countFacilities());
+    }
+
+    @Test
+    public void testRoomImmutability() {
+        // Iterators should not cause representation exposure
+        Iterator<Room> iter = bA.roomIterator();
+        boolean flag = false;
+        try {
+            iter.remove();
+        } catch (Exception e) {
+            flag = true;
+        }
+
+        assertTrue(flag);
+        assertEquals(roomsA.size(), bA.countRooms());
     }
 }


### PR DESCRIPTION
…f representation exposure, edited test cases such that each node has unique ID